### PR TITLE
[Feat] #3 - 디테일뷰 메인섹션[0] 헤더 구현

### DIFF
--- a/NAVER-MAP-iOS.xcodeproj/project.pbxproj
+++ b/NAVER-MAP-iOS.xcodeproj/project.pbxproj
@@ -220,6 +220,8 @@
 		6BAD1AAA2B0A660600837590 /* Detail */ = {
 			isa = PBXGroup;
 			children = (
+				94F380A92B0CA9E800657538 /* View */,
+				94F380A82B0CA9DB00657538 /* Layout */,
 				6BAD1AB02B0A665900837590 /* DetailViewController.swift */,
 			);
 			path = Detail;
@@ -242,6 +244,36 @@
 				6BAD1ADC2B0C7EA300837590 /* Pretendard-SemiBold.otf */,
 			);
 			path = Font;
+			sourceTree = "<group>";
+		};
+		94F380A82B0CA9DB00657538 /* Layout */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Layout;
+			sourceTree = "<group>";
+		};
+		94F380A92B0CA9E800657538 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				94F380AB2B0CA9F700657538 /* SupplementaryView */,
+				94F380AA2B0CA9F000657538 /* Cell */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		94F380AA2B0CA9F000657538 /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		94F380AB2B0CA9F700657538 /* SupplementaryView */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SupplementaryView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/NAVER-MAP-iOS.xcodeproj/project.pbxproj
+++ b/NAVER-MAP-iOS.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		6BAD1ADE2B0C7EA300837590 /* Pretendard-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 6BAD1ADA2B0C7EA300837590 /* Pretendard-Regular.otf */; };
 		6BAD1ADF2B0C7EA300837590 /* Pretendard-Medium.otf in Resources */ = {isa = PBXBuildFile; fileRef = 6BAD1ADB2B0C7EA300837590 /* Pretendard-Medium.otf */; };
 		6BAD1AE02B0C7EA300837590 /* Pretendard-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 6BAD1ADC2B0C7EA300837590 /* Pretendard-SemiBold.otf */; };
+		94F380AD2B0CAF0E00657538 /* DetailMainSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F380AC2B0CAF0E00657538 /* DetailMainSectionHeaderView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +61,7 @@
 		6BAD1ADA2B0C7EA300837590 /* Pretendard-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Regular.otf"; sourceTree = "<group>"; };
 		6BAD1ADB2B0C7EA300837590 /* Pretendard-Medium.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-Medium.otf"; sourceTree = "<group>"; };
 		6BAD1ADC2B0C7EA300837590 /* Pretendard-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Pretendard-SemiBold.otf"; sourceTree = "<group>"; };
+		94F380AC2B0CAF0E00657538 /* DetailMainSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailMainSectionHeaderView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -272,6 +274,7 @@
 		94F380AB2B0CA9F700657538 /* SupplementaryView */ = {
 			isa = PBXGroup;
 			children = (
+				94F380AC2B0CAF0E00657538 /* DetailMainSectionHeaderView.swift */,
 			);
 			path = SupplementaryView;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				6BAD1AAF2B0A665000837590 /* SearchResultViewController.swift in Sources */,
 				6BAD1AB12B0A665900837590 /* DetailViewController.swift in Sources */,
 				6BAD1ABD2B0A66C200837590 /* UIView+.swift in Sources */,
+				94F380AD2B0CAF0E00657538 /* DetailMainSectionHeaderView.swift in Sources */,
 				6B4D96DD2B08657600977A82 /* SceneDelegate.swift in Sources */,
 				6BAD1AC12B0A66E300837590 /* ImageLiterals.swift in Sources */,
 				6BAD1ACB2B0A683600837590 /* UITextField+.swift in Sources */,

--- a/NAVER-MAP-iOS/Global/Consts/ColorLiterals.swift
+++ b/NAVER-MAP-iOS/Global/Consts/ColorLiterals.swift
@@ -12,7 +12,7 @@ extension UIColor {
     // MARK: - Black Gray White
     
     static var naverMapBlack: UIColor {
-        return UIColor(hex: "#00000")
+        return UIColor(hex: "#000000")
     }
     
     static var naverMapGray8: UIColor {

--- a/NAVER-MAP-iOS/Screen/Detail/DetailViewController.swift
+++ b/NAVER-MAP-iOS/Screen/Detail/DetailViewController.swift
@@ -8,22 +8,119 @@
 import UIKit
 
 class DetailViewController: UIViewController {
-
+    
+    // MARK: - UI Properties
+    
+    private lazy var detailCollectionView: UICollectionView = { createCollectionView() }()
+    
+    // MARK: - LifeCycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        setupViews()
+        setupLayout()
+        setupCollectionViewConfig()
+    }
+}
 
-        // Do any additional setup after loading the view.
+// MARK: - Private Method
+
+private extension DetailViewController {
+    
+    func setupViews() {
+        self.navigationController?.isNavigationBarHidden = true
+        view.addSubviews([detailCollectionView])
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    func setupLayout() {
+        detailCollectionView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
     }
-    */
-
+    
+    func setupCollectionViewConfig() {
+        self.detailCollectionView.register(DetailMainSectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: DetailMainSectionHeaderView.identifier)
+        
+        self.detailCollectionView.delegate = self
+        self.detailCollectionView.dataSource = self
+    }
+    
+    // MARK: - Method for creating UI properties
+    
+    func createLayout() -> UICollectionViewLayout {
+        return UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            if sectionIndex == 0 {
+                return self.createFirstSectionLayout()
+            } else {
+                return self.createFirstSectionLayout()
+            }
+        }
+    }
+    
+    func createFirstSectionLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(0)) // 아이템 없음
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.boundarySupplementaryItems = [self.createSectionHeader()]
+        return section
+    }
+    
+    func createOtherSectionLayout() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .absolute(0)) // 아이템 없음
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.boundarySupplementaryItems = [self.createSectionHeader()]
+        return section
+    }
+    
+    func createSectionHeader() -> NSCollectionLayoutBoundarySupplementaryItem {
+        let layoutSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .fractionalWidth(1.0))
+        let header = NSCollectionLayoutBoundarySupplementaryItem(layoutSize: layoutSize, elementKind: UICollectionView.elementKindSectionHeader, alignment: .top)
+        return header
+    }
+    
+    func createCollectionView() -> UICollectionView {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+        collectionView.backgroundColor = UIColor.naverMapWhite
+        collectionView.showsVerticalScrollIndicator = false
+        collectionView.showsHorizontalScrollIndicator = false
+        return collectionView
+    }
 }
+
+// MARK: - CollectionView DataSource
+
+extension DetailViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 0
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        return UICollectionViewCell()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
+        guard kind == UICollectionView.elementKindSectionHeader else {
+            return UICollectionReusableView()
+        }
+        let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: DetailMainSectionHeaderView.identifier, for: indexPath) as! DetailMainSectionHeaderView
+        return headerView
+    }
+}
+
+// MARK: - CollectionVeiw Delegate
+
+extension DetailViewController: UICollectionViewDelegate {
+    
+}
+
+

--- a/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
+++ b/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
@@ -224,4 +224,30 @@ private extension DetailMainSectionHeaderView {
            }
        }
        
+    func setupProperties() {
+           paginatorBtn.do {
+               $0.setImage(ImageLiterals.ic_arrow_left_g6, for: .normal)
+           }
+           
+           departureBtn.do {
+               $0.setTitle("출발", for: .normal)
+               $0.titleLabel?.font = UIFont.body7
+               $0.setTitleColor(UIColor.naverMapBlue, for: .normal)
+               $0.setImage(ImageLiterals.ic_btn_depart_circle, for: .normal)
+               $0.layer.borderWidth = 1
+               $0.layer.borderColor = UIColor.naverMapBlue.cgColor
+               $0.layer.backgroundColor = UIColor.naverMapWhite.cgColor
+               $0.layer.cornerRadius = 20
+           }
+           
+           arrivalBtn.do {
+               $0.setTitle("도착", for: .normal)
+               $0.titleLabel?.font = UIFont.body7
+               $0.setTitleColor(UIColor.naverMapWhite, for: .normal)
+               $0.setImage(ImageLiterals.ic_btn_location_white, for: .normal)
+               $0.layer.backgroundColor = UIColor.naverMapBlue.cgColor
+               $0.layer.cornerRadius = 20
+           }
+       }
+    
 }

--- a/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
+++ b/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
@@ -144,4 +144,84 @@ private extension DetailMainSectionHeaderView {
         
         naverBtnStackView.addArrangedSubviews(bookingBtn, payBtn)
     }
+    
+    func setupLayout() {
+           imagesHorizontalStackView.snp.makeConstraints {
+               $0.top.equalToSuperview()
+               $0.leading.equalToSuperview()
+               $0.width.equalToSuperview()
+               $0.height.equalTo(188)
+           }
+           
+           paginatorBtn.snp.makeConstraints {
+               $0.top.equalTo(imagesHorizontalStackView).inset(8)
+               $0.leading.equalTo(imagesHorizontalStackView).inset(16)
+           }
+           
+           imageIc.snp.makeConstraints {
+               $0.top.equalTo(imagesHorizontalStackView).inset(123)
+               $0.trailing.equalTo(imagesHorizontalStackView).inset(36)
+           }
+           
+           imagesCountLabel.snp.makeConstraints {
+               $0.top.equalTo(imageIc).inset(4)
+               $0.trailing.equalTo(imagesHorizontalStackView).inset(36)
+           }
+           
+           locationNameLabel.snp.makeConstraints {
+               $0.top.equalTo(imagesHorizontalStackView.snp.bottom).inset(21)
+               $0.leading.equalToSuperview().inset(17)
+           }
+           
+           categoryLabel.snp.makeConstraints {
+               $0.top.equalTo(imagesHorizontalStackView.snp.bottom).inset(22)
+               $0.leading.equalTo(locationNameLabel.snp.trailing).inset(4)
+           }
+           
+           descriptionLabel.snp.makeConstraints {
+               $0.top.equalTo(locationNameLabel.snp.bottom).inset(8)
+               $0.leading.equalToSuperview().inset(17)
+           }
+           
+           rateIc.snp.makeConstraints {
+               $0.top.equalTo(descriptionLabel.snp.bottom).inset(18)
+               $0.leading.equalToSuperview().inset(17)
+           }
+           
+           rateLabel.snp.makeConstraints {
+               $0.top.equalTo(descriptionLabel.snp.bottom).inset(15)
+               $0.leading.equalTo(rateIc.snp.trailing).inset(2)
+           }
+           
+           visitorReviewBtn.snp.makeConstraints {
+               $0.top.equalTo(descriptionLabel.snp.bottom).inset(13)
+               $0.leading.equalTo(rateLabel.snp.trailing).inset(16)
+           }
+           
+           blogReviewBtn.snp.makeConstraints {
+               $0.top.equalTo(descriptionLabel.snp.bottom).inset(13)
+               $0.leading.equalTo(visitorReviewBtn.snp.trailing).inset(8)
+           }
+           
+           mapBtnStackView.snp.makeConstraints {
+               $0.top.equalTo(visitorReviewBtn.snp.bottom).inset(16)
+               $0.centerX.equalToSuperview()
+           }
+           
+           horizontalDividingLine.snp.makeConstraints {
+               $0.top.equalTo(mapBtnStackView.snp.bottom).inset(18)
+               $0.centerX.equalToSuperview()
+           }
+           
+           allMenusStackView.snp.makeConstraints {
+               $0.top.equalTo(horizontalDividingLine.snp.bottom).inset(9)
+               $0.centerX.equalToSuperview()
+           }
+           
+           naverBtnStackView.snp.makeConstraints {
+               $0.top.equalTo(horizontalDividingLine.snp.bottom).inset(75)
+               $0.centerX.equalToSuperview()
+           }
+       }
+       
 }

--- a/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
+++ b/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
@@ -101,3 +101,47 @@ class DetailMainSectionHeaderView: UICollectionReusableView {
         fatalError("init(coder:) has not been implemented")
     }
 }
+
+// MARK: - Private method
+
+private extension DetailMainSectionHeaderView {
+    func setupStyle() {
+        self.backgroundColor = UIColor.naverMapWhite
+    }
+    
+    func setupViews() {
+        self.addSubviews([imagesHorizontalStackView,
+                          locationNameLabel,
+                          categoryLabel,
+                          descriptionLabel,
+                          rateIc,
+                          rateLabel,
+                          visitorReviewBtn,
+                          blogReviewBtn,
+                          mapBtnStackView,
+                          horizontalDividingLine,
+                          allMenusStackView,
+                          naverBtnStackView])
+        imagesHorizontalStackView.addSubviews([paginatorBtn, imageIc, imagesCountLabel])
+        
+        imagesHorizontalStackView.addArrangedSubviews(bigMenuImage ,imagesVerticalStackView1, imagesVerticalStackView2)
+        imagesVerticalStackView1.addArrangedSubviews(smallMenuImage1, smallMenuImage2)
+        imagesVerticalStackView2.addArrangedSubviews(smallMenuImage3, smallMenuImage4)
+        mapBtnStackView.addArrangedSubviews(visitorReviewBtn, blogReviewBtn)
+        
+        allMenusStackView.addArrangedSubviews(callStackView,
+                                              verticalDividingLine1,
+                                              bookMarkStackView,
+                                              verticalDividingLine1,
+                                              navigationStackView,
+                                              verticalDividingLine1,
+                                              shareStackView)
+        
+        callStackView.addArrangedSubviews(callIc, callMenuLabel)
+        bookMarkStackView.addArrangedSubviews(bookMarkIc, bookMarkMenuLabel)
+        navigationStackView.addArrangedSubviews(navigationIc, navigationMenuLabel)
+        shareStackView.addArrangedSubviews(navigationIc, navigationMenuLabel)
+        
+        naverBtnStackView.addArrangedSubviews(bookingBtn, payBtn)
+    }
+}

--- a/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
+++ b/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
@@ -15,7 +15,6 @@ class DetailMainSectionHeaderView: UICollectionReusableView {
     // MARK: - Properties
     
     static let identifier = "DetailMainSectionHeaderView"
-    private var buttonConfig = UIButton.Configuration.filled() // 이걸 여기에? 아니면 메서드 안에?
     
     // MARK: - UI Properties
     
@@ -25,11 +24,11 @@ class DetailMainSectionHeaderView: UICollectionReusableView {
     private lazy var imagesVerticalStackView1: UIStackView = { createVerticalStackView(forSpacing: 2) }()
     private lazy var imagesVerticalStackView2: UIStackView = { createVerticalStackView(forSpacing: 2) }()
     
-    private lazy var bigMenuImage: UIImageView = { fetchBigImageLayout(image: ImageLiterals.ic_food) }()
-    private lazy var smallMenuImage1: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_btn_location_white)}()
-    private lazy var smallMenuImage2: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_btn_location_white) }()
-    private lazy var smallMenuImage3: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_btn_location_white) }()
-    private lazy var smallMenuImage4: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_btn_location_white)}()
+    private lazy var bigMenuImage: UIImageView = { fetchBigImageLayout(image: ImageLiterals.ic_naverbooking) }()
+    private lazy var smallMenuImage1: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_naverbooking)}()
+    private lazy var smallMenuImage2: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_naverbooking) }()
+    private lazy var smallMenuImage3: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_naverbooking) }()
+    private lazy var smallMenuImage4: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_naverbooking)}()
     private lazy var imageIc: UIImageView = { createIcon(image: ImageLiterals.ic_picture) }()
     private lazy var imagesCountLabel = createLabel(forFont: UIFont.bodyButton, forColor: UIColor.naverMapWhite, text: "+4")
     
@@ -42,7 +41,6 @@ class DetailMainSectionHeaderView: UICollectionReusableView {
     private lazy var rateIc: UIImageView = { createIcon(image: ImageLiterals.ic_star_red) }()
     private lazy var rateLabel: UILabel = { createLabel(forFont: UIFont.body7, forColor: UIColor.naverMapGray7, text: "4.82")}()
     
-    private let mainStackView = UIStackView()
     private lazy var visitorReviewBtn = createReviewBtn(title: "방문자리뷰 288")
     private lazy var blogReviewBtn = createReviewBtn(title: "블로그리뷰 316")
     
@@ -50,8 +48,11 @@ class DetailMainSectionHeaderView: UICollectionReusableView {
     private let departureBtn = UIButton()
     private let arrivalBtn = UIButton()
     
-    private lazy var horizontalDividingLine: UIView = { createDividingLine(forHeight: 1, forWidth: 343) }()
-    
+    private let horizontalDividingLine = UIView()
+    private let verticalDividingLine1 = UIView()
+    private let verticalDividingLine2 = UIView()
+    private let verticalDividingLine3 = UIView()
+
     private lazy var allMenusStackView: UIStackView = { createHorizontalStackView(forSpacing: 29) }()
     
     private lazy var callStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
@@ -59,22 +60,18 @@ class DetailMainSectionHeaderView: UICollectionReusableView {
     private lazy var callMenuLabel: UILabel = { createLabel(forFont: UIFont.body10,
                                                             forColor: UIColor.naverMapGray6,
                                                             text: "전화")}()
-    private lazy var verticalDividingLine1: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
     
     private lazy var bookMarkStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
     private lazy var bookMarkIc: UIImageView = { createIcon(image: ImageLiterals.ic_star_thick) }()
     private lazy var bookMarkMenuLabel: UILabel = { createLabel(forFont: UIFont.body10,
                                                                 forColor: UIColor.naverMapGray6,
                                                                 text: "저장")}()
-    private lazy var verticalDividingLine2: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
     
     private lazy var navigationStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
     private lazy var navigationIc: UIImageView = { createIcon(image: ImageLiterals.ic_navigation) }()
     private lazy var navigationMenuLabel: UILabel = { createLabel(forFont: UIFont.body10,
                                                                   forColor: UIColor.naverMapGray6,
                                                                   text: "내비게이션")}()
-    private lazy var verticalDividingLine3: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
-    
     
     private lazy var shareStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
     private lazy var shareIc: UIImageView = { createIcon(image: ImageLiterals.ic_share) }()
@@ -93,7 +90,7 @@ class DetailMainSectionHeaderView: UICollectionReusableView {
         
         setupStyle()
         setupViews()
-        setupLayout()
+        setupConstraints()
         setupProperties()
     }
     
@@ -122,30 +119,35 @@ private extension DetailMainSectionHeaderView {
                           horizontalDividingLine,
                           allMenusStackView,
                           naverBtnStackView])
-        imagesHorizontalStackView.addSubviews([paginatorBtn, imageIc, imagesCountLabel])
         
-        imagesHorizontalStackView.addArrangedSubviews(bigMenuImage ,imagesVerticalStackView1, imagesVerticalStackView2)
+        imagesHorizontalStackView.addArrangedSubviews(bigMenuImage,
+                                                      imagesVerticalStackView1,
+                                                      imagesVerticalStackView2)
         imagesVerticalStackView1.addArrangedSubviews(smallMenuImage1, smallMenuImage2)
         imagesVerticalStackView2.addArrangedSubviews(smallMenuImage3, smallMenuImage4)
-        mapBtnStackView.addArrangedSubviews(visitorReviewBtn, blogReviewBtn)
-        
+        imagesHorizontalStackView.addSubviews([paginatorBtn, 
+                                               imageIc, 
+                                               imagesCountLabel])
+
+        mapBtnStackView.addArrangedSubviews(departureBtn, arrivalBtn)
+
         allMenusStackView.addArrangedSubviews(callStackView,
                                               verticalDividingLine1,
                                               bookMarkStackView,
-                                              verticalDividingLine1,
+                                              verticalDividingLine2,
                                               navigationStackView,
-                                              verticalDividingLine1,
+                                              verticalDividingLine3,
                                               shareStackView)
-        
+                
         callStackView.addArrangedSubviews(callIc, callMenuLabel)
         bookMarkStackView.addArrangedSubviews(bookMarkIc, bookMarkMenuLabel)
         navigationStackView.addArrangedSubviews(navigationIc, navigationMenuLabel)
-        shareStackView.addArrangedSubviews(navigationIc, navigationMenuLabel)
+        shareStackView.addArrangedSubviews(shareIc, shareMenuLabel)
         
         naverBtnStackView.addArrangedSubviews(bookingBtn, payBtn)
     }
     
-    func setupLayout() {
+    func setupConstraints() {
         imagesHorizontalStackView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.leading.equalToSuperview()
@@ -159,68 +161,106 @@ private extension DetailMainSectionHeaderView {
         }
         
         imageIc.snp.makeConstraints {
-            $0.top.equalTo(imagesHorizontalStackView).inset(123)
+            $0.top.equalTo(imagesHorizontalStackView).offset(123)
             $0.trailing.equalTo(imagesHorizontalStackView).inset(36)
         }
         
         imagesCountLabel.snp.makeConstraints {
-            $0.top.equalTo(imageIc).inset(4)
+            $0.top.equalTo(imageIc.snp.bottom).offset(4)
             $0.trailing.equalTo(imagesHorizontalStackView).inset(36)
         }
         
         locationNameLabel.snp.makeConstraints {
-            $0.top.equalTo(imagesHorizontalStackView.snp.bottom).inset(21)
+            $0.top.equalTo(imagesHorizontalStackView.snp.bottom).offset(21)
             $0.leading.equalToSuperview().inset(17)
         }
         
         categoryLabel.snp.makeConstraints {
-            $0.top.equalTo(imagesHorizontalStackView.snp.bottom).inset(22)
-            $0.leading.equalTo(locationNameLabel.snp.trailing).inset(4)
+            $0.top.equalTo(imagesHorizontalStackView.snp.bottom).offset(22)
+            $0.leading.equalTo(locationNameLabel.snp.trailing).offset(4)
         }
         
         descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(locationNameLabel.snp.bottom).inset(8)
+            $0.top.equalTo(locationNameLabel.snp.bottom).offset(8)
             $0.leading.equalToSuperview().inset(17)
         }
         
         rateIc.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).inset(18)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(18)
             $0.leading.equalToSuperview().inset(17)
+            $0.height.equalTo(12)
+            $0.width.equalTo(12)
         }
         
         rateLabel.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).inset(15)
-            $0.leading.equalTo(rateIc.snp.trailing).inset(2)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(18)
+            $0.leading.equalToSuperview().inset(31)
         }
         
         visitorReviewBtn.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).inset(13)
-            $0.leading.equalTo(rateLabel.snp.trailing).inset(16)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(14)
+            $0.leading.equalTo(rateLabel.snp.trailing).offset(16)
+            $0.width.equalTo(104)
+            $0.height.equalTo(23)
         }
         
         blogReviewBtn.snp.makeConstraints {
-            $0.top.equalTo(descriptionLabel.snp.bottom).inset(13)
-            $0.leading.equalTo(visitorReviewBtn.snp.trailing).inset(8)
+            $0.top.equalTo(descriptionLabel.snp.bottom).offset(14)
+            $0.leading.equalTo(visitorReviewBtn.snp.trailing).offset(8)
+            $0.width.equalTo(104)
+            $0.height.equalTo(23)
         }
         
         mapBtnStackView.snp.makeConstraints {
-            $0.top.equalTo(visitorReviewBtn.snp.bottom).inset(16)
+            $0.top.equalTo(visitorReviewBtn.snp.bottom).offset(16)
             $0.centerX.equalToSuperview()
         }
         
+        arrivalBtn.snp.makeConstraints {
+            $0.width.equalTo(94)
+            $0.height.equalTo(36)
+        }
+        
+        departureBtn.snp.makeConstraints {
+            $0.width.equalTo(94)
+            $0.height.equalTo(36)
+        }
+        
         horizontalDividingLine.snp.makeConstraints {
-            $0.top.equalTo(mapBtnStackView.snp.bottom).inset(18)
+            $0.top.equalTo(mapBtnStackView.snp.bottom).offset(18)
             $0.centerX.equalToSuperview()
         }
         
         allMenusStackView.snp.makeConstraints {
-            $0.top.equalTo(horizontalDividingLine.snp.bottom).inset(9)
+            $0.top.equalTo(horizontalDividingLine.snp.bottom).offset(9)
             $0.centerX.equalToSuperview()
         }
         
         naverBtnStackView.snp.makeConstraints {
-            $0.top.equalTo(horizontalDividingLine.snp.bottom).inset(75)
+            $0.top.equalTo(horizontalDividingLine.snp.bottom).offset(75)
             $0.centerX.equalToSuperview()
+        }
+        
+        bookingBtn.snp.makeConstraints {
+            $0.width.equalTo(160)
+            $0.height.equalTo(40)
+        }
+        
+        payBtn.snp.makeConstraints {
+            $0.width.equalTo(160)
+            $0.height.equalTo(40)
+        }
+        
+        horizontalDividingLine.snp.makeConstraints {
+            $0.width.equalTo(343)
+            $0.height.equalTo(1)
+        }
+        
+        for i in [verticalDividingLine1, verticalDividingLine2, verticalDividingLine3] {
+            i.snp.makeConstraints {
+                $0.width.equalTo(1)
+                $0.height.equalTo(46)
+            }
         }
     }
     
@@ -236,7 +276,7 @@ private extension DetailMainSectionHeaderView {
             $0.setImage(ImageLiterals.ic_btn_depart_circle, for: .normal)
             $0.layer.borderWidth = 1
             $0.layer.borderColor = UIColor.naverMapBlue.cgColor
-            $0.layer.backgroundColor = UIColor.naverMapWhite.cgColor
+            $0.backgroundColor = UIColor.naverMapWhite
             $0.layer.cornerRadius = 20
         }
         
@@ -245,8 +285,15 @@ private extension DetailMainSectionHeaderView {
             $0.titleLabel?.font = UIFont.body7
             $0.setTitleColor(UIColor.naverMapWhite, for: .normal)
             $0.setImage(ImageLiterals.ic_btn_location_white, for: .normal)
-            $0.layer.backgroundColor = UIColor.naverMapBlue.cgColor
+            $0.backgroundColor = UIColor.naverMapBlue
             $0.layer.cornerRadius = 20
+        }
+        
+        for i in [horizontalDividingLine,
+                  verticalDividingLine1,
+                  verticalDividingLine2,
+                  verticalDividingLine3] {
+            i.backgroundColor = UIColor.naverMapGray2
         }
     }
     
@@ -271,11 +318,11 @@ private extension DetailMainSectionHeaderView {
     }
     
     func createReviewBtn(title: String) -> UIButton { //inset 주기
-        let btn = UIButton(configuration: buttonConfig)
+        let btn = UIButton()
         btn.setTitle(title, for: .normal)
         btn.setTitleColor(UIColor.naverMapGray7, for: .normal)
         btn.titleLabel?.font = UIFont.body7
-        btn.layer.backgroundColor = UIColor.naverMapReview5.cgColor
+        btn.backgroundColor = UIColor.naverMapReview5
         btn.layer.borderColor = UIColor.naverMapReview4.cgColor
         btn.layer.borderWidth = 1
         btn.layer.cornerRadius = 3
@@ -283,15 +330,15 @@ private extension DetailMainSectionHeaderView {
     }
     
     func createNaverBtn(title: String, image: UIImage) -> UIButton {
-        let btn = UIButton(configuration: buttonConfig)
+        let btn = UIButton()
         btn.setTitle(title, for: .normal)
         btn.setTitleColor(UIColor.naverMapGray6, for: .normal)
+        btn.setImage(image, for: .normal)
         btn.titleLabel?.font = UIFont.body7
-        btn.layer.backgroundColor = UIColor.naverMapWhite.cgColor
+        btn.backgroundColor = UIColor.naverMapWhite
         btn.layer.borderColor = UIColor.naverMapGray2.cgColor
         btn.layer.borderWidth = 1
         btn.layer.cornerRadius = 8
-        btn.configuration?.contentInsets = NSDirectionalEdgeInsets.init(top: 8, leading: 55, bottom: 8, trailing: 55)
         return btn
     }
     
@@ -310,19 +357,13 @@ private extension DetailMainSectionHeaderView {
         return ic
     }
     
-    func createDividingLine(forHeight: CGFloat, forWidth: CGFloat) -> UIView {
-        let line = UIView()
-        line.backgroundColor = UIColor.naverMapBlueGray2
-        line.frame = CGRect(x: 0, y: 0, width: forWidth, height: forHeight)
-        return line
-    }
-    
     func fetchImageLayout(image: UIImage) -> UIImageView {
         let img = UIImageView()
         img.snp.makeConstraints {
             $0.width.equalTo( getDeviceWidth() / 4 )
             $0.height.equalTo( getDeviceWidth() / 4 )
         }
+        img.image = image
         return img
     }
     
@@ -332,6 +373,7 @@ private extension DetailMainSectionHeaderView {
             $0.width.equalTo( getDeviceWidth() / 2 )
             $0.height.equalTo( getDeviceWidth() / 2 )
         }
+        img.image = image
         return img
     }
 }

--- a/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
+++ b/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
@@ -1,0 +1,103 @@
+//
+//  DetailMainSectionHeaderView.swift
+//  NAVER-MAP-iOS
+//
+//  Created by 윤영서 on 11/21/23.
+//
+
+import UIKit
+
+import Then
+import SnapKit
+
+class DetailMainSectionHeaderView: UICollectionReusableView {
+    
+    // MARK: - Properties
+    
+    static let identifier = "DetailMainSectionHeaderView"
+    private var buttonConfig = UIButton.Configuration.filled() // 이걸 여기에? 아니면 메서드 안에?
+    
+    // MARK: - UI Properties
+    
+    private let paginatorBtn = UIButton()
+    
+    private lazy var imagesHorizontalStackView: UIStackView = { createHorizontalStackView(forSpacing: 2) }()
+    private lazy var imagesVerticalStackView1: UIStackView = { createVerticalStackView(forSpacing: 2) }()
+    private lazy var imagesVerticalStackView2: UIStackView = { createVerticalStackView(forSpacing: 2) }()
+    
+    private lazy var bigMenuImage: UIImageView = { fetchBigImageLayout(image: ImageLiterals.ic_food) }()
+    private lazy var smallMenuImage1: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_btn_location_white)}()
+    private lazy var smallMenuImage2: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_btn_location_white) }()
+    private lazy var smallMenuImage3: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_btn_location_white) }()
+    private lazy var smallMenuImage4: UIImageView = { fetchImageLayout(image: ImageLiterals.ic_btn_location_white)}()
+    private lazy var imageIc: UIImageView = { createIcon(image: ImageLiterals.ic_picture) }()
+    private lazy var imagesCountLabel = createLabel(forFont: UIFont.bodyButton, forColor: UIColor.naverMapWhite, text: "+4")
+    
+    private lazy var locationNameLabel: UILabel = { createLabel(forFont: UIFont.title2, forColor: UIColor.naverMapBlack, text: "알고")}()
+    private lazy var categoryLabel: UILabel = { createLabel(forFont: UIFont.body7, forColor: UIColor.naverMapGray4, text: "스파게티, 파스타 전문")}()
+    private lazy var descriptionLabel: UILabel = { createLabel(forFont: UIFont.body7,
+                                                               forColor: UIColor.naverMapGray6,
+                                                               text: "수제맥주를 즐길 수 있는 어린이대공원 파스타 맛집")}()
+    
+    private lazy var rateIc: UIImageView = { createIcon(image: ImageLiterals.ic_star_red) }()
+    private lazy var rateLabel: UILabel = { createLabel(forFont: UIFont.body7, forColor: UIColor.naverMapGray7, text: "4.82")}()
+    
+    private let mainStackView = UIStackView()
+    private lazy var visitorReviewBtn = createReviewBtn(title: "방문자리뷰 288")
+    private lazy var blogReviewBtn = createReviewBtn(title: "블로그리뷰 316")
+    
+    private lazy var mapBtnStackView: UIStackView = { createHorizontalStackView(forSpacing: 6) }()
+    private let departureBtn = UIButton()
+    private let arrivalBtn = UIButton()
+    
+    private lazy var horizontalDividingLine: UIView = { createDividingLine(forHeight: 1, forWidth: 343) }()
+
+    private lazy var allMenusStackView: UIStackView = { createHorizontalStackView(forSpacing: 29) }()
+    
+    private lazy var callStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
+    private lazy var callIc: UIImageView = { createIcon(image: ImageLiterals.ic_call_thick) }()
+    private lazy var callMenuLabel: UILabel = { createLabel(forFont: UIFont.body10, 
+                                                            forColor: UIColor.naverMapGray6,
+                                                            text: "전화")}()
+    private lazy var verticalDividingLine1: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
+    
+    private lazy var bookMarkStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
+    private lazy var bookMarkIc: UIImageView = { createIcon(image: ImageLiterals.ic_star_thick) }()
+    private lazy var bookMarkMenuLabel: UILabel = { createLabel(forFont: UIFont.body10, 
+                                                                forColor: UIColor.naverMapGray6,
+                                                                text: "저장")}()
+    private lazy var verticalDividingLine2: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
+
+    private lazy var navigationStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
+    private lazy var navigationIc: UIImageView = { createIcon(image: ImageLiterals.ic_navigation) }()
+    private lazy var navigationMenuLabel: UILabel = { createLabel(forFont: UIFont.body10, 
+                                                                  forColor: UIColor.naverMapGray6,
+                                                                  text: "내비게이션")}()
+    private lazy var verticalDividingLine3: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
+
+
+    private lazy var shareStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
+    private lazy var shareIc: UIImageView = { createIcon(image: ImageLiterals.ic_share) }()
+    private lazy var shareMenuLabel: UILabel = { createLabel(forFont: UIFont.body10, 
+                                                             forColor: UIColor.naverMapGray6,
+                                                             text: "공유")}()
+
+    private lazy var naverBtnStackView: UIStackView = { createHorizontalStackView(forSpacing: 23) }()
+    private lazy var bookingBtn = createNaverBtn(title: "예약", image: ImageLiterals.ic_naverbooking_24)
+    private lazy var payBtn = createNaverBtn(title: "주문", image: ImageLiterals.ic_naverorder_24)
+    
+    // MARK: - Life Cycle
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupStyle()
+        setupViews()
+        setupLayout()
+        setupProperties()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
+++ b/NAVER-MAP-iOS/Screen/Detail/View/SupplementaryView/DetailMainSectionHeaderView.swift
@@ -51,37 +51,37 @@ class DetailMainSectionHeaderView: UICollectionReusableView {
     private let arrivalBtn = UIButton()
     
     private lazy var horizontalDividingLine: UIView = { createDividingLine(forHeight: 1, forWidth: 343) }()
-
+    
     private lazy var allMenusStackView: UIStackView = { createHorizontalStackView(forSpacing: 29) }()
     
     private lazy var callStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
     private lazy var callIc: UIImageView = { createIcon(image: ImageLiterals.ic_call_thick) }()
-    private lazy var callMenuLabel: UILabel = { createLabel(forFont: UIFont.body10, 
+    private lazy var callMenuLabel: UILabel = { createLabel(forFont: UIFont.body10,
                                                             forColor: UIColor.naverMapGray6,
                                                             text: "전화")}()
     private lazy var verticalDividingLine1: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
     
     private lazy var bookMarkStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
     private lazy var bookMarkIc: UIImageView = { createIcon(image: ImageLiterals.ic_star_thick) }()
-    private lazy var bookMarkMenuLabel: UILabel = { createLabel(forFont: UIFont.body10, 
+    private lazy var bookMarkMenuLabel: UILabel = { createLabel(forFont: UIFont.body10,
                                                                 forColor: UIColor.naverMapGray6,
                                                                 text: "저장")}()
     private lazy var verticalDividingLine2: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
-
+    
     private lazy var navigationStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
     private lazy var navigationIc: UIImageView = { createIcon(image: ImageLiterals.ic_navigation) }()
-    private lazy var navigationMenuLabel: UILabel = { createLabel(forFont: UIFont.body10, 
+    private lazy var navigationMenuLabel: UILabel = { createLabel(forFont: UIFont.body10,
                                                                   forColor: UIColor.naverMapGray6,
                                                                   text: "내비게이션")}()
     private lazy var verticalDividingLine3: UIView = { createDividingLine(forHeight: 46, forWidth: 1) }()
-
-
+    
+    
     private lazy var shareStackView: UIStackView = { createVerticalStackView(forSpacing: 6) }()
     private lazy var shareIc: UIImageView = { createIcon(image: ImageLiterals.ic_share) }()
-    private lazy var shareMenuLabel: UILabel = { createLabel(forFont: UIFont.body10, 
+    private lazy var shareMenuLabel: UILabel = { createLabel(forFont: UIFont.body10,
                                                              forColor: UIColor.naverMapGray6,
                                                              text: "공유")}()
-
+    
     private lazy var naverBtnStackView: UIStackView = { createHorizontalStackView(forSpacing: 23) }()
     private lazy var bookingBtn = createNaverBtn(title: "예약", image: ImageLiterals.ic_naverbooking_24)
     private lazy var payBtn = createNaverBtn(title: "주문", image: ImageLiterals.ic_naverorder_24)
@@ -146,108 +146,192 @@ private extension DetailMainSectionHeaderView {
     }
     
     func setupLayout() {
-           imagesHorizontalStackView.snp.makeConstraints {
-               $0.top.equalToSuperview()
-               $0.leading.equalToSuperview()
-               $0.width.equalToSuperview()
-               $0.height.equalTo(188)
-           }
-           
-           paginatorBtn.snp.makeConstraints {
-               $0.top.equalTo(imagesHorizontalStackView).inset(8)
-               $0.leading.equalTo(imagesHorizontalStackView).inset(16)
-           }
-           
-           imageIc.snp.makeConstraints {
-               $0.top.equalTo(imagesHorizontalStackView).inset(123)
-               $0.trailing.equalTo(imagesHorizontalStackView).inset(36)
-           }
-           
-           imagesCountLabel.snp.makeConstraints {
-               $0.top.equalTo(imageIc).inset(4)
-               $0.trailing.equalTo(imagesHorizontalStackView).inset(36)
-           }
-           
-           locationNameLabel.snp.makeConstraints {
-               $0.top.equalTo(imagesHorizontalStackView.snp.bottom).inset(21)
-               $0.leading.equalToSuperview().inset(17)
-           }
-           
-           categoryLabel.snp.makeConstraints {
-               $0.top.equalTo(imagesHorizontalStackView.snp.bottom).inset(22)
-               $0.leading.equalTo(locationNameLabel.snp.trailing).inset(4)
-           }
-           
-           descriptionLabel.snp.makeConstraints {
-               $0.top.equalTo(locationNameLabel.snp.bottom).inset(8)
-               $0.leading.equalToSuperview().inset(17)
-           }
-           
-           rateIc.snp.makeConstraints {
-               $0.top.equalTo(descriptionLabel.snp.bottom).inset(18)
-               $0.leading.equalToSuperview().inset(17)
-           }
-           
-           rateLabel.snp.makeConstraints {
-               $0.top.equalTo(descriptionLabel.snp.bottom).inset(15)
-               $0.leading.equalTo(rateIc.snp.trailing).inset(2)
-           }
-           
-           visitorReviewBtn.snp.makeConstraints {
-               $0.top.equalTo(descriptionLabel.snp.bottom).inset(13)
-               $0.leading.equalTo(rateLabel.snp.trailing).inset(16)
-           }
-           
-           blogReviewBtn.snp.makeConstraints {
-               $0.top.equalTo(descriptionLabel.snp.bottom).inset(13)
-               $0.leading.equalTo(visitorReviewBtn.snp.trailing).inset(8)
-           }
-           
-           mapBtnStackView.snp.makeConstraints {
-               $0.top.equalTo(visitorReviewBtn.snp.bottom).inset(16)
-               $0.centerX.equalToSuperview()
-           }
-           
-           horizontalDividingLine.snp.makeConstraints {
-               $0.top.equalTo(mapBtnStackView.snp.bottom).inset(18)
-               $0.centerX.equalToSuperview()
-           }
-           
-           allMenusStackView.snp.makeConstraints {
-               $0.top.equalTo(horizontalDividingLine.snp.bottom).inset(9)
-               $0.centerX.equalToSuperview()
-           }
-           
-           naverBtnStackView.snp.makeConstraints {
-               $0.top.equalTo(horizontalDividingLine.snp.bottom).inset(75)
-               $0.centerX.equalToSuperview()
-           }
-       }
-       
-    func setupProperties() {
-           paginatorBtn.do {
-               $0.setImage(ImageLiterals.ic_arrow_left_g6, for: .normal)
-           }
-           
-           departureBtn.do {
-               $0.setTitle("출발", for: .normal)
-               $0.titleLabel?.font = UIFont.body7
-               $0.setTitleColor(UIColor.naverMapBlue, for: .normal)
-               $0.setImage(ImageLiterals.ic_btn_depart_circle, for: .normal)
-               $0.layer.borderWidth = 1
-               $0.layer.borderColor = UIColor.naverMapBlue.cgColor
-               $0.layer.backgroundColor = UIColor.naverMapWhite.cgColor
-               $0.layer.cornerRadius = 20
-           }
-           
-           arrivalBtn.do {
-               $0.setTitle("도착", for: .normal)
-               $0.titleLabel?.font = UIFont.body7
-               $0.setTitleColor(UIColor.naverMapWhite, for: .normal)
-               $0.setImage(ImageLiterals.ic_btn_location_white, for: .normal)
-               $0.layer.backgroundColor = UIColor.naverMapBlue.cgColor
-               $0.layer.cornerRadius = 20
-           }
-       }
+        imagesHorizontalStackView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.leading.equalToSuperview()
+            $0.width.equalToSuperview()
+            $0.height.equalTo(188)
+        }
+        
+        paginatorBtn.snp.makeConstraints {
+            $0.top.equalTo(imagesHorizontalStackView).inset(8)
+            $0.leading.equalTo(imagesHorizontalStackView).inset(16)
+        }
+        
+        imageIc.snp.makeConstraints {
+            $0.top.equalTo(imagesHorizontalStackView).inset(123)
+            $0.trailing.equalTo(imagesHorizontalStackView).inset(36)
+        }
+        
+        imagesCountLabel.snp.makeConstraints {
+            $0.top.equalTo(imageIc).inset(4)
+            $0.trailing.equalTo(imagesHorizontalStackView).inset(36)
+        }
+        
+        locationNameLabel.snp.makeConstraints {
+            $0.top.equalTo(imagesHorizontalStackView.snp.bottom).inset(21)
+            $0.leading.equalToSuperview().inset(17)
+        }
+        
+        categoryLabel.snp.makeConstraints {
+            $0.top.equalTo(imagesHorizontalStackView.snp.bottom).inset(22)
+            $0.leading.equalTo(locationNameLabel.snp.trailing).inset(4)
+        }
+        
+        descriptionLabel.snp.makeConstraints {
+            $0.top.equalTo(locationNameLabel.snp.bottom).inset(8)
+            $0.leading.equalToSuperview().inset(17)
+        }
+        
+        rateIc.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).inset(18)
+            $0.leading.equalToSuperview().inset(17)
+        }
+        
+        rateLabel.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).inset(15)
+            $0.leading.equalTo(rateIc.snp.trailing).inset(2)
+        }
+        
+        visitorReviewBtn.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).inset(13)
+            $0.leading.equalTo(rateLabel.snp.trailing).inset(16)
+        }
+        
+        blogReviewBtn.snp.makeConstraints {
+            $0.top.equalTo(descriptionLabel.snp.bottom).inset(13)
+            $0.leading.equalTo(visitorReviewBtn.snp.trailing).inset(8)
+        }
+        
+        mapBtnStackView.snp.makeConstraints {
+            $0.top.equalTo(visitorReviewBtn.snp.bottom).inset(16)
+            $0.centerX.equalToSuperview()
+        }
+        
+        horizontalDividingLine.snp.makeConstraints {
+            $0.top.equalTo(mapBtnStackView.snp.bottom).inset(18)
+            $0.centerX.equalToSuperview()
+        }
+        
+        allMenusStackView.snp.makeConstraints {
+            $0.top.equalTo(horizontalDividingLine.snp.bottom).inset(9)
+            $0.centerX.equalToSuperview()
+        }
+        
+        naverBtnStackView.snp.makeConstraints {
+            $0.top.equalTo(horizontalDividingLine.snp.bottom).inset(75)
+            $0.centerX.equalToSuperview()
+        }
+    }
     
+    func setupProperties() {
+        paginatorBtn.do {
+            $0.setImage(ImageLiterals.ic_arrow_left_g6, for: .normal)
+        }
+        
+        departureBtn.do {
+            $0.setTitle("출발", for: .normal)
+            $0.titleLabel?.font = UIFont.body7
+            $0.setTitleColor(UIColor.naverMapBlue, for: .normal)
+            $0.setImage(ImageLiterals.ic_btn_depart_circle, for: .normal)
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.naverMapBlue.cgColor
+            $0.layer.backgroundColor = UIColor.naverMapWhite.cgColor
+            $0.layer.cornerRadius = 20
+        }
+        
+        arrivalBtn.do {
+            $0.setTitle("도착", for: .normal)
+            $0.titleLabel?.font = UIFont.body7
+            $0.setTitleColor(UIColor.naverMapWhite, for: .normal)
+            $0.setImage(ImageLiterals.ic_btn_location_white, for: .normal)
+            $0.layer.backgroundColor = UIColor.naverMapBlue.cgColor
+            $0.layer.cornerRadius = 20
+        }
+    }
+    
+    // MARK: - create UI components method
+    
+    func createVerticalStackView(forSpacing: CGFloat) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = forSpacing
+        stackView.distribution = .equalSpacing
+        stackView.alignment = .center
+        return stackView
+    }
+    
+    func createHorizontalStackView(forSpacing: CGFloat) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = forSpacing
+        stackView.distribution = .equalSpacing
+        stackView.alignment = .center
+        return stackView
+    }
+    
+    func createReviewBtn(title: String) -> UIButton { //inset 주기
+        let btn = UIButton(configuration: buttonConfig)
+        btn.setTitle(title, for: .normal)
+        btn.setTitleColor(UIColor.naverMapGray7, for: .normal)
+        btn.titleLabel?.font = UIFont.body7
+        btn.layer.backgroundColor = UIColor.naverMapReview5.cgColor
+        btn.layer.borderColor = UIColor.naverMapReview4.cgColor
+        btn.layer.borderWidth = 1
+        btn.layer.cornerRadius = 3
+        return btn
+    }
+    
+    func createNaverBtn(title: String, image: UIImage) -> UIButton {
+        let btn = UIButton(configuration: buttonConfig)
+        btn.setTitle(title, for: .normal)
+        btn.setTitleColor(UIColor.naverMapGray6, for: .normal)
+        btn.titleLabel?.font = UIFont.body7
+        btn.layer.backgroundColor = UIColor.naverMapWhite.cgColor
+        btn.layer.borderColor = UIColor.naverMapGray2.cgColor
+        btn.layer.borderWidth = 1
+        btn.layer.cornerRadius = 8
+        btn.configuration?.contentInsets = NSDirectionalEdgeInsets.init(top: 8, leading: 55, bottom: 8, trailing: 55)
+        return btn
+    }
+    
+    func createLabel(forFont: UIFont, forColor: UIColor, text: String) -> UILabel {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = forFont
+        label.text = text
+        label.textColor = forColor
+        return label
+    }
+    
+    func createIcon(image: UIImage) -> UIImageView {
+        let ic = UIImageView()
+        ic.image = image
+        return ic
+    }
+    
+    func createDividingLine(forHeight: CGFloat, forWidth: CGFloat) -> UIView {
+        let line = UIView()
+        line.backgroundColor = UIColor.naverMapBlueGray2
+        line.frame = CGRect(x: 0, y: 0, width: forWidth, height: forHeight)
+        return line
+    }
+    
+    func fetchImageLayout(image: UIImage) -> UIImageView {
+        let img = UIImageView()
+        img.snp.makeConstraints {
+            $0.width.equalTo( getDeviceWidth() / 4 )
+            $0.height.equalTo( getDeviceWidth() / 4 )
+        }
+        return img
+    }
+    
+    func fetchBigImageLayout(image: UIImage) -> UIImageView {
+        let img = UIImageView()
+        img.snp.makeConstraints {
+            $0.width.equalTo( getDeviceWidth() / 2 )
+            $0.height.equalTo( getDeviceWidth() / 2 )
+        }
+        return img
+    }
 }


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #3 


### ✅ 작업한 내용
<!-- 작업한 내용 적어주세요! -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->
- 첫번째 섹션의 경우, 컬렉션 뷰의 헤더로만 구성되도록 구현했습니다.


### ❗️PR Point
<!-- 부족했던 점 혹은 개선하고 싶은 방향이 있다면 얘기해주세요 -->

<!--
```
넣고싶은 코드가 있다면 적어주세요
```
-->
- 객체들이 엄청 많은데, 더 효율적으로 바꿀 수 있는 부분 말씀해주시면 감사하겠습니다!🌟
- 현재 UIButton들의 inset 디테일이 맞지 않는 상황입니다.
    - UIButton의 경우, iOS 15 이후로 contentInsets 등의 inset 관련 속성을 지원하지 않고,
configuration을 지원한다고 합니다. 관련해서 더 찾아본 뒤에 디테일 잡도록 하겠습니다. 
- DetailViewController에 Compositional Layout 코드를 모아둔 상태입니다. 
    - 따로 Factory 디자인 패턴 등을 활용해서 다른 파일에 빼서 가독성 높이도록 하겠습니다. 
- 서버통신 고려해서 따로 더미데이터 파일 만들어 동적으로 데이터 가져오도록 하겠습니다.  
- 별점의 별 아이콘의 경우, 피그마 상 소수점으로 레이아웃이 잡혀있어서 디자이너 선생님과의 소통 후 수정하겠습니다. 

- 위에 사항들 반영 후, 앞으로 2번째 섹션 작업 이어서 하도록 하겠습니다. 

### 📸 스크린샷
<!-- 스크린 샷을 첨부해주세요 -->

<img src = "https://github.com/DO-SOPT-APP6-NAVER-MAP/NAVER-MAP-iOS/assets/102219161/f5fc59bb-7a07-410a-8455-f79540650f95" width=60%>



### Resolved
: N/A

### CheckList
- [x] SceneDelegate RootVC 복구
- [x] 불필요한 주석 및 코드 삭제