### PR TITLE
[Feat] #4 - BottomSheet 뷰 UI 구현

### DIFF
--- a/NAVER-MAP-iOS/Global/Extensions/UILabel+.swift
+++ b/NAVER-MAP-iOS/Global/Extensions/UILabel+.swift
@@ -45,4 +45,12 @@ extension UILabel {
         }
         self.attributedText = attributedString
     }
+    
+    /// UILabel 기본 세팅  => 폰트, 텍스트, 텍스트색상, 정렬방법(옵션)
+    func setupLabel(font: UIFont, text: String, textColor: UIColor, alignment: NSTextAlignment? = nil) {
+        self.font = font
+        self.text = text
+        self.textColor = textColor
+        self.textAlignment = alignment ?? .center
+    }
 }

--- a/NAVER-MAP-iOS/Global/Extensions/UIStackView+.swift
+++ b/NAVER-MAP-iOS/Global/Extensions/UIStackView+.swift
@@ -26,7 +26,7 @@ extension UIStackView {
     
     /// 기본 스택뷰 세팅 함수
     func setupStackView(bgColor: UIColor, axis: NSLayoutConstraint.Axis, distribution: Distribution, spacing: CGFloat? = nil) {
-        self.backgroundColor = .naverMapGray1
+        self.backgroundColor = bgColor
         self.axis = axis
         self.distribution = distribution
         self.spacing = spacing ?? 0

--- a/NAVER-MAP-iOS/Global/Extensions/UIStackView+.swift
+++ b/NAVER-MAP-iOS/Global/Extensions/UIStackView+.swift
@@ -23,4 +23,12 @@ extension UIStackView {
             $0.removeFromSuperview()
         }
     }
+    
+    /// 기본 스택뷰 세팅 함수
+    func setupStackView(bgColor: UIColor, axis: NSLayoutConstraint.Axis, distribution: Distribution, spacing: CGFloat? = nil) {
+        self.backgroundColor = .naverMapGray1
+        self.axis = axis
+        self.distribution = distribution
+        self.spacing = spacing ?? 0
+    }
 }

--- a/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
+++ b/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
@@ -87,6 +87,7 @@ class SearchResultViewController: UIViewController {
         locationInfoGroup.addSubviews([distance, dot, location, dropBtn])
         resultInfoGroup.addSubviews([status, lastOrder])
         reviewGroup.addSubviews([reviewIcon, score, visitorReview, blogReview])
+        imgGroup.addArrangedSubviews(img1, img2, img3)
         
         ///상단 서치뷰
         topBarView.snp.makeConstraints{
@@ -136,7 +137,7 @@ class SearchResultViewController: UIViewController {
         ///하단 바텀시트뷰
         bottomSheetView.snp.makeConstraints{
             $0.leading.bottom.trailing.equalToSuperview()
-            $0.height.equalTo(bottomSheetView.getDeviceHeight()/7 * 3)
+            $0.height.equalTo(bottomSheetView.convertByHeightRatio(399))
         }
         dragIcon.snp.makeConstraints{
             $0.top.equalTo(bottomSheetView).inset(14)
@@ -232,9 +233,13 @@ class SearchResultViewController: UIViewController {
             $0.leading.equalTo(visitorReview.snp.trailing).offset(8)
             $0.width.equalTo(104)
         }
+        ///리뷰 사진
+        imgGroup.snp.makeConstraints{
+            $0.height.equalTo(imgGroup.convertByHeightRatio(90))
+        }
         
         divider.snp.makeConstraints{
-            $0.top.equalTo(stackView.snp.bottom)
+            $0.top.equalTo(stackView.snp.bottom).offset(14)
             $0.height.equalTo(1)
             $0.leading.trailing.equalToSuperview()
         }
@@ -304,7 +309,7 @@ class SearchResultViewController: UIViewController {
             $0.layer.cornerRadius = 2
             $0.backgroundColor = .naverMapBlueGray4
         }
-        stackView.setupStackView(bgColor: .naverMapGray1, axis: .vertical, distribution: .fillProportionally, spacing: 13)
+        stackView.setupStackView(bgColor: .naverMapGray1, axis: .vertical, distribution: .fillProportionally, spacing: stackView.convertByHeightRatio(9))
         
         ///상단 네이버 아이콘 그룹
         pay.setImage(ImageLiterals.caption_naverpay, for: .normal)
@@ -336,6 +341,12 @@ class SearchResultViewController: UIViewController {
         score.setupLabel(font: .body7, text: "4.82", textColor: .naverMapGray7)
         visitorReview.setupRoundedLabel(text: "방문자리뷰 288", font: .body7, textColor: .naverMapGray7, alignment: .center, bgColor: UIColor.naverMapReview5, borderColor: UIColor.naverMapReview4, borderWidth: 1, radius: 3)
         blogReview.setupRoundedLabel(text: "블로그리뷰 316", font: .body7, textColor: .naverMapGray7, alignment: .center, bgColor: UIColor.naverMapReview5, borderColor: UIColor.naverMapReview4, borderWidth: 1, radius: 3)
+        
+        /// 리뷰 이미지
+        imgGroup.setupStackView(bgColor: .naverMapWhite, axis: .horizontal, distribution: .fillEqually, spacing: 4)
+        img1.setupImageView(image: ImageLiterals.img_beating_heart, maskedCorners: [.layerMinXMinYCorner, .layerMinXMaxYCorner] , radius: 6, borderColor: UIColor.naverMapGray1, width: 1)
+        img2.setupImageView(image: ImageLiterals.img_beating_heart, radius: 0, borderColor: UIColor.naverMapGray1, width: 1)
+        img3.setupImageView(image: ImageLiterals.img_beating_heart, maskedCorners: [.layerMaxXMinYCorner, .layerMaxXMaxYCorner] , radius: 6, borderColor: UIColor.naverMapGray1, width: 1)
         
         divider.do{
             $0.backgroundColor = .naverMapBlack5
@@ -373,5 +384,20 @@ extension UILabel {
         self.layer.borderColor = borderColor.cgColor
         self.layer.borderWidth = borderWidth
         self.layer.cornerRadius = radius
+    }
+}
+
+extension UIImageView {
+    
+    ///이미지뷰 세팅 함수
+    func setupImageView(image: UIImage, maskedCorners: CACornerMask? = nil, radius: CGFloat? = nil, borderColor: UIColor, width: CGFloat) {
+        self.image = image
+        if let corners = maskedCorners {
+            self.layer.maskedCorners = corners
+        }
+        self.layer.masksToBounds = true
+        self.layer.cornerRadius = radius ?? 0
+        self.layer.borderColor = borderColor.cgColor
+        self.layer.borderWidth = width
     }
 }

--- a/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
+++ b/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
@@ -56,8 +56,8 @@ class SearchResultViewController: UIViewController {
     private var favorites = UIButton()
     private var share = UIButton()
     private var btnGroup = UIStackView()
-    private var departure = UIButton()
-    private var arrival = UIButton()
+    private var departure = UILabel()
+    private var arrival = UILabel()
     
     // MARK: Properties
    
@@ -88,6 +88,9 @@ class SearchResultViewController: UIViewController {
         resultInfoGroup.addSubviews([status, lastOrder])
         reviewGroup.addSubviews([reviewIcon, score, visitorReview, blogReview])
         imgGroup.addArrangedSubviews(img1, img2, img3)
+        bottomView.addSubviews([bottomIconGroup, btnGroup])
+        bottomIconGroup.addArrangedSubviews(reservation, contact, favorites, share)
+        btnGroup.addArrangedSubviews(departure, arrival)
         
         ///상단 서치뷰
         topBarView.snp.makeConstraints{
@@ -150,6 +153,7 @@ class SearchResultViewController: UIViewController {
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.height.equalTo(stackView.getDeviceHeight() / 3)
         }
+        
         ///상단 네이버 아이콘 그룹
         topIconGroup.snp.makeConstraints{
             $0.height.equalTo(13)
@@ -166,6 +170,7 @@ class SearchResultViewController: UIViewController {
             $0.leading.equalTo(booking.snp.trailing).offset(8)
             $0.top.bottom.equalToSuperview()
         }
+        
         ///검색 결과 이름 & 카테고리
         resultTitleGroup.snp.makeConstraints{
             $0.height.equalTo(20)
@@ -178,11 +183,13 @@ class SearchResultViewController: UIViewController {
             $0.leading.equalTo(name.snp.trailing).offset(4)
             $0.top.bottom.equalToSuperview()
         }
-        ///검색 결과 이름 & 카테고리
+        
+        ///검색 결과 상세 설명
         detail.snp.makeConstraints{
             $0.height.equalTo(19)
             $0.leading.equalToSuperview()
         }
+        
         ///검색 결과 위치정보
         locationInfoGroup.snp.makeConstraints{
             $0.height.equalTo(18)
@@ -202,6 +209,7 @@ class SearchResultViewController: UIViewController {
             $0.leading.equalTo(location.snp.trailing).offset(3)
             $0.width.height.equalTo(18)
         }
+        
         ///검색 결과 영업 정보
         resultInfoGroup.snp.makeConstraints{
             $0.height.equalTo(19)
@@ -212,6 +220,7 @@ class SearchResultViewController: UIViewController {
         lastOrder.snp.makeConstraints{
             $0.leading.equalTo(status.snp.trailing).offset(16)
         }
+        
         /// 리뷰 정보
         reviewGroup.snp.makeConstraints{
             $0.height.equalTo(23)
@@ -233,21 +242,34 @@ class SearchResultViewController: UIViewController {
             $0.leading.equalTo(visitorReview.snp.trailing).offset(8)
             $0.width.equalTo(104)
         }
+        
         ///리뷰 사진
         imgGroup.snp.makeConstraints{
             $0.height.equalTo(imgGroup.convertByHeightRatio(90))
         }
         
+        ///구분선
         divider.snp.makeConstraints{
             $0.top.equalTo(stackView.snp.bottom).offset(14)
             $0.height.equalTo(1)
             $0.leading.trailing.equalToSuperview()
         }
+        
+        ///하단 바텀뷰
         bottomView.snp.makeConstraints{
             $0.top.equalTo(divider.snp.bottom)
-            $0.bottom.equalToSuperview()
+            $0.bottom.equalTo(self.view.safeAreaLayoutGuide)
             $0.leading.trailing.equalToSuperview().inset(20)
         }
+        bottomIconGroup.snp.makeConstraints{
+            $0.top.bottom.leading.equalToSuperview()
+        }
+        btnGroup.snp.makeConstraints{
+            $0.centerY.trailing.equalToSuperview()
+            $0.width.equalTo(btnGroup.convertByWidthRatio(138))
+            $0.height.equalTo(btnGroup.convertByHeightRatio(31))
+        }
+        
     }
     
     // MARK: - Style
@@ -283,7 +305,7 @@ class SearchResultViewController: UIViewController {
         mapView.do{
             $0.setRegion(MKCoordinateRegion(center: defaultLocation, span: defaultSpanValue), animated: true)
         }
-        mapBtnStackView.setupStackView(bgColor: .clear, axis: .vertical, distribution: .fillEqually)
+        mapBtnStackView.setupStackView(bgColor: .clear, axis: .vertical, distribution: .fillEqually, spacing: 7)
         menuBtn.setImage(ImageLiterals.ic_copy, for: .normal)
         favoritesBtn.setImage(ImageLiterals.ic_star_fill, for: .normal)
         roadViewBtn.setImage(ImageLiterals.ic_location_remove, for: .normal)
@@ -309,7 +331,7 @@ class SearchResultViewController: UIViewController {
             $0.layer.cornerRadius = 2
             $0.backgroundColor = .naverMapBlueGray4
         }
-        stackView.setupStackView(bgColor: .naverMapGray1, axis: .vertical, distribution: .fillProportionally, spacing: stackView.convertByHeightRatio(9))
+        stackView.setupStackView(bgColor: .naverMapWhite, axis: .vertical, distribution: .fillProportionally, spacing: stackView.convertByHeightRatio(9))
         
         ///상단 네이버 아이콘 그룹
         pay.setImage(ImageLiterals.caption_naverpay, for: .normal)
@@ -348,12 +370,22 @@ class SearchResultViewController: UIViewController {
         img2.setupImageView(image: ImageLiterals.img_beating_heart, radius: 0, borderColor: UIColor.naverMapGray1, width: 1)
         img3.setupImageView(image: ImageLiterals.img_beating_heart, maskedCorners: [.layerMaxXMinYCorner, .layerMaxXMaxYCorner] , radius: 6, borderColor: UIColor.naverMapGray1, width: 1)
         
+        ///구분선
         divider.do{
             $0.backgroundColor = .naverMapBlack5
         }
-        bottomView.do{
-            $0.backgroundColor = .gray
-        }
+        
+        ///하단 바텀뷰
+        bottomIconGroup.setupStackView(bgColor: .naverMapWhite, axis: .horizontal, distribution: .fillEqually, spacing: 20)
+        reservation.setImage(ImageLiterals.ic_navercal, for: .normal)
+        contact.setImage(ImageLiterals.ic_call_thick, for: .normal)
+        favorites.setImage(ImageLiterals.ic_star_thick, for: .normal)
+        share.setImage(ImageLiterals.ic_share, for: .normal)
+        btnGroup.setupStackView(bgColor: .naverMapWhite, axis: .horizontal, distribution: .fillEqually, spacing: 6)
+        departure.setupRoundedLabel(text: "출발", font: .body7, textColor: .naverMapBlue, alignment: .center, bgColor: .naverMapWhite, borderColor: .naverMapBlue, borderWidth: 1, radius: 16)
+        departure.attributedText = NSAttributedString(string: departure.text!, attributes: [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue])
+        arrival.setupRoundedLabel(text: "도착", font: .body7, textColor: .naverMapWhite, alignment: .center, bgColor: .naverMapBlue, borderColor: .naverMapWhite, borderWidth: 1, radius: 16)
+        arrival.attributedText = NSAttributedString(string: arrival.text!, attributes: [NSAttributedString.Key.underlineStyle: NSUnderlineStyle.single.rawValue])
     }
     
     // TODO: 바텀시트컨트롤러 추후 수정
@@ -384,6 +416,7 @@ extension UILabel {
         self.layer.borderColor = borderColor.cgColor
         self.layer.borderWidth = borderWidth
         self.layer.cornerRadius = radius
+        self.layer.masksToBounds = true
     }
 }
 

--- a/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
+++ b/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
@@ -236,11 +236,7 @@ class SearchResultViewController: UIViewController {
             $0.layer.borderColor = UIColor.naverMapGray4.cgColor
             $0.layer.borderWidth = 1
         }
-        topStackView.do{
-            $0.axis = .horizontal
-            $0.backgroundColor = .white
-            $0.distribution = .equalSpacing
-        }
+        topStackView.setupStackView(bgColor: .naverMapWhite, axis: .horizontal, distribution: .equalSpacing)
         backBtn.setImage(ImageLiterals.ic_arrow_left_g6, for: .normal)
         searchTextfield.do{
             $0.addPadding(left: 12, right: 12)
@@ -259,12 +255,7 @@ class SearchResultViewController: UIViewController {
         mapView.do{
             $0.setRegion(MKCoordinateRegion(center: defaultLocation, span: defaultSpanValue), animated: true)
         }
-        mapBtnStackView.do{
-            $0.axis = .vertical
-            $0.backgroundColor = .clear
-            $0.distribution = .fillEqually
-            $0.spacing = 7
-        }
+        mapBtnStackView.setupStackView(bgColor: .clear, axis: .vertical, distribution: .fillEqually)
         menuBtn.setImage(ImageLiterals.ic_copy, for: .normal)
         favoritesBtn.setImage(ImageLiterals.ic_star_fill, for: .normal)
         roadViewBtn.setImage(ImageLiterals.ic_location_remove, for: .normal)
@@ -290,13 +281,7 @@ class SearchResultViewController: UIViewController {
             $0.layer.cornerRadius = 2
             $0.backgroundColor = .naverMapBlueGray4
         }
-        stackView.do{
-            $0.backgroundColor = .naverMapGray1
-            $0.axis = .vertical
-            $0.distribution = .fillProportionally
-            $0.spacing = 13
-        }
-        ///하단 바텀시트뷰
+        stackView.setupStackView(bgColor: .naverMapGray1, axis: .vertical, distribution: .fillProportionally, spacing: 13)
         ///상단 네이버 아이콘 그룹
         topIconGroup.do{
             $0.backgroundColor = .blue
@@ -304,22 +289,12 @@ class SearchResultViewController: UIViewController {
         pay.setImage(ImageLiterals.caption_naverpay, for: .normal)
         booking.setImage(ImageLiterals.caption_naverbooking, for: .normal)
         order.setImage(ImageLiterals.caption_naverorder, for: .normal)
-        ///하단 바텀시트뷰
         ///검색결과 이름 & 카테고리
         resultTitleGroup.do{
             $0.backgroundColor = .yellow
         }
-        name.do{
-            $0.text = "알고"
-            $0.font = .title2
-            $0.textColor = .naverMapSubBlue
-        }
-        category.do{
-            $0.text = "스파게티, 파스타전문"
-            $0.font = .body10
-            $0.textColor = .naverMapGray4
-        }
-        ///하단 바텀시트뷰
+        name.setupLabel(font: .title2, text: "알고", textColor: .naverMapSubBlue)
+        category.setupLabel(font: .body10, text: "스파게티, 파스타전문", textColor: .naverMapGray4)
         ///검색 결과 이름 & 카테고리
         detail.do{
             $0.text = "수제맥주를 즐길 수 있는 어린이대공원 파스타 맛집"
@@ -373,6 +348,14 @@ class SearchResultViewController: UIViewController {
             $0.backgroundColor = .gray
         }
     }
+    
+//    func setupLabel(label: UILabel, font: UIFont, text: String, textColor: UIColor, alignment: NSTextAlignment? = nil) {
+////        let label = UILabel()
+//        label.font = font
+//        label.text = text
+//        label.textColor = textColor
+//        label.textAlignment = alignment ?? .center
+//    }
     
     func showMyViewControllerInACustomizedSheet() {
         let detailVC = DetailViewController()

--- a/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
+++ b/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
@@ -40,6 +40,10 @@ class SearchResultViewController: UIViewController {
     private var status = UILabel()
     private var lastOrder = UILabel()
     private var reviewGroup = UIView()
+    private var reviewIcon = UIButton()
+    private var score = UILabel()
+    private var visitorReview = UILabel()
+    private var blogReview = UILabel()
     private var imgGroup = UIStackView()
     private var img1 = UIImageView()
     private var img2 = UIImageView()
@@ -82,6 +86,7 @@ class SearchResultViewController: UIViewController {
         resultTitleGroup.addSubviews([name, category])
         locationInfoGroup.addSubviews([distance, dot, location, dropBtn])
         resultInfoGroup.addSubviews([status, lastOrder])
+        reviewGroup.addSubviews([reviewIcon, score, visitorReview, blogReview])
         
         ///상단 서치뷰
         topBarView.snp.makeConstraints{
@@ -150,15 +155,15 @@ class SearchResultViewController: UIViewController {
         }
         pay.snp.makeConstraints{
             $0.leading.equalToSuperview()
-            $0.height.equalTo(13)
+            $0.top.bottom.equalToSuperview()
         }
         booking.snp.makeConstraints{
             $0.leading.equalTo(pay.snp.trailing).offset(8)
-            $0.height.equalTo(13)
+            $0.top.bottom.equalToSuperview()
         }
         order.snp.makeConstraints{
             $0.leading.equalTo(booking.snp.trailing).offset(8)
-            $0.height.equalTo(13)
+            $0.top.bottom.equalToSuperview()
         }
         ///검색 결과 이름 & 카테고리
         resultTitleGroup.snp.makeConstraints{
@@ -166,13 +171,11 @@ class SearchResultViewController: UIViewController {
         }
         name.snp.makeConstraints{
             $0.leading.equalToSuperview()
-            $0.height.equalTo(20)
-            $0.bottom.equalToSuperview()
+            $0.top.bottom.equalToSuperview()
         }
         category.snp.makeConstraints{
             $0.leading.equalTo(name.snp.trailing).offset(4)
-            $0.height.equalTo(18)
-            $0.bottom.equalToSuperview()
+            $0.top.bottom.equalToSuperview()
         }
         ///검색 결과 이름 & 카테고리
         detail.snp.makeConstraints{
@@ -208,7 +211,27 @@ class SearchResultViewController: UIViewController {
         lastOrder.snp.makeConstraints{
             $0.leading.equalTo(status.snp.trailing).offset(16)
         }
-        
+        /// 리뷰 정보
+        reviewGroup.snp.makeConstraints{
+            $0.height.equalTo(23)
+        }
+        reviewIcon.snp.makeConstraints{
+            $0.leading.centerY.equalToSuperview()
+        }
+        score.snp.makeConstraints{
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalTo(reviewIcon.snp.trailing).offset(2)
+        }
+        visitorReview.snp.makeConstraints{
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalTo(score.snp.trailing).offset(16)
+            $0.width.equalTo(104)
+        }
+        blogReview.snp.makeConstraints{
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalTo(visitorReview.snp.trailing).offset(8)
+            $0.width.equalTo(104)
+        }
         
         divider.snp.makeConstraints{
             $0.top.equalTo(stackView.snp.bottom)
@@ -308,10 +331,12 @@ class SearchResultViewController: UIViewController {
         status.setupLabel(font: .body6, text: "영업 중", textColor: .naverMapNaverGreen)
         lastOrder.setupLabel(font: .body7, text: "22:00에 라스트오더", textColor: .naverMapGray7)
 
+        ///리뷰 정보
+        reviewIcon.setImage(ImageLiterals.ic_star_red, for: .normal)
+        score.setupLabel(font: .body7, text: "4.82", textColor: .naverMapGray7)
+        visitorReview.setupRoundedLabel(text: "방문자리뷰 288", font: .body7, textColor: .naverMapGray7, alignment: .center, bgColor: UIColor.naverMapReview5, borderColor: UIColor.naverMapReview4, borderWidth: 1, radius: 3)
+        blogReview.setupRoundedLabel(text: "블로그리뷰 316", font: .body7, textColor: .naverMapGray7, alignment: .center, bgColor: UIColor.naverMapReview5, borderColor: UIColor.naverMapReview4, borderWidth: 1, radius: 3)
         
-        imgGroup.do{
-            $0.backgroundColor = .orange
-        }
         divider.do{
             $0.backgroundColor = .naverMapBlack5
         }
@@ -336,3 +361,17 @@ class SearchResultViewController: UIViewController {
     }
 }
 
+extension UILabel {
+    
+    ///둥근 테두리의 리뷰 라벨 세팅 함수
+    func setupRoundedLabel(text: String, font: UIFont, textColor: UIColor, alignment: NSTextAlignment, bgColor: UIColor, borderColor: UIColor, borderWidth: CGFloat, radius: CGFloat) {
+        self.text = text
+        self.font = font
+        self.textColor = textColor
+        self.textAlignment = alignment
+        self.backgroundColor = bgColor
+        self.layer.borderColor = borderColor.cgColor
+        self.layer.borderWidth = borderWidth
+        self.layer.cornerRadius = radius
+    }
+}

--- a/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
+++ b/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
@@ -282,61 +282,32 @@ class SearchResultViewController: UIViewController {
             $0.backgroundColor = .naverMapBlueGray4
         }
         stackView.setupStackView(bgColor: .naverMapGray1, axis: .vertical, distribution: .fillProportionally, spacing: 13)
+        
         ///상단 네이버 아이콘 그룹
-        topIconGroup.do{
-            $0.backgroundColor = .blue
-        }
         pay.setImage(ImageLiterals.caption_naverpay, for: .normal)
         booking.setImage(ImageLiterals.caption_naverbooking, for: .normal)
         order.setImage(ImageLiterals.caption_naverorder, for: .normal)
+        
         ///검색결과 이름 & 카테고리
-        resultTitleGroup.do{
-            $0.backgroundColor = .yellow
-        }
         name.setupLabel(font: .title2, text: "알고", textColor: .naverMapSubBlue)
         category.setupLabel(font: .body10, text: "스파게티, 파스타전문", textColor: .naverMapGray4)
+        
         ///검색 결과 이름 & 카테고리
-        detail.do{
-            $0.text = "수제맥주를 즐길 수 있는 어린이대공원 파스타 맛집"
-            $0.font = .body7
-            $0.textColor = .naverMapGray6
-            $0.backgroundColor = .systemPink
-        }
+        detail.setupLabel(font: .body7, text: "수제맥주를 즐길 수 있는 어린이대공원 파스타 맛집", textColor: .naverMapGray6, alignment: .left)
+        
         ///검색 결과 위치정보
-        locationInfoGroup.do{
-            $0.backgroundColor = .purple
-        }
-        distance.do{
-            $0.text = "936m"
-            $0.font = .body3
-            $0.textColor = .naverMapGray6
-        }
+        distance.setupLabel(font: .body3, text: "936m", textColor: .naverMapGray6)
         dot.do{
             $0.layer.cornerRadius = 1
             $0.backgroundColor = .naverMapGray3
         }
-        location.do{
-            $0.text = "서울 광진구"
-            $0.font = .bodyButton
-            $0.textColor = .naverMapGray6
-        }
-        dropBtn.do{
-            $0.setImage(ImageLiterals.ic_arrow_down, for: .normal)
-        }
+        location.setupLabel(font: .bodyButton, text: "서울 광진구", textColor: .naverMapGray6)
+        dropBtn.setImage(ImageLiterals.ic_arrow_down, for: .normal)
+
         ///검색 결과 영업 정보
-        resultInfoGroup.do{
-            $0.backgroundColor = .green
-        }
-        status.do{
-            $0.text = "영업 중"
-            $0.font = .body6
-            $0.textColor = .naverMapNaverGreen
-        }
-        lastOrder.do{
-            $0.text = "22:00에 라스트오더"
-            $0.font = .body7
-            $0.textColor = .naverMapGray7
-        }
+        status.setupLabel(font: .body6, text: "영업 중", textColor: .naverMapNaverGreen)
+        lastOrder.setupLabel(font: .body7, text: "22:00에 라스트오더", textColor: .naverMapGray7)
+
         
         imgGroup.do{
             $0.backgroundColor = .orange
@@ -349,14 +320,9 @@ class SearchResultViewController: UIViewController {
         }
     }
     
-//    func setupLabel(label: UILabel, font: UIFont, text: String, textColor: UIColor, alignment: NSTextAlignment? = nil) {
-////        let label = UILabel()
-//        label.font = font
-//        label.text = text
-//        label.textColor = textColor
-//        label.textAlignment = alignment ?? .center
-//    }
+    // TODO: 바텀시트컨트롤러 추후 수정
     
+    ///바텀시트 컨트롤러 -> 추후 수정 예정
     func showMyViewControllerInACustomizedSheet() {
         let detailVC = DetailViewController()
         if let sheet = detailVC.sheetPresentationController {

--- a/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
+++ b/NAVER-MAP-iOS/Screen/SearchResult/SearchResultViewController.swift
@@ -67,13 +67,14 @@ class SearchResultViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setupView()
         setupLayout()
         setupStyle()
     }
 
-    // MARK: - Layout
+    // MARK: - View
     
-    func setupLayout(){
+    func setupView(){
         self.view.addSubviews([topBarView, mapView, bottomSheetView])
         topBarView.addSubview(topStackView)
         topStackView.addArrangedSubviews(backBtn, searchTextfield, exitBtn)
@@ -91,6 +92,11 @@ class SearchResultViewController: UIViewController {
         bottomView.addSubviews([bottomIconGroup, btnGroup])
         bottomIconGroup.addArrangedSubviews(reservation, contact, favorites, share)
         btnGroup.addArrangedSubviews(departure, arrival)
+    }
+    
+    // MARK: - Layout
+    
+    func setupLayout(){
         
         ///상단 서치뷰
         topBarView.snp.makeConstraints{


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #4 


### ✅ 작업한 내용
- [x] 지도
   - [x] Map View
   - [x] 좌측 상단 버튼 그룹
   - [x] 우측 하단 '위치' 버튼


### ❗️PR Point
- 둥근 테두리의 라벨 세팅 함수 생성
- 이미지뷰 세팅 함수
- 기본 스택뷰 세팅 함수
=> 여러 번 사용되는 것들을 함수로 분리시켰습니다
=> 둥근 테두리 라벨이나 이미지뷰는 결과 뷰에서만 사용되는 것 같아서 따로 extension 파일에 넣어두진 않았는데 혹시 필요하다면 파일에 넣어두도록 하겠습니다!
<img width="1120" alt="스크린샷 2023-11-24 오전 4 51 20" src="https://github.com/DO-SOPT-APP6-NAVER-MAP/NAVER-MAP-iOS/assets/105407130/1067642c-636e-4ba2-9aa0-66770b7e846a">
<img width="1120" alt="스크린샷 2023-11-24 오전 4 51 42" src="https://github.com/DO-SOPT-APP6-NAVER-MAP/NAVER-MAP-iOS/assets/105407130/7a6962fc-7b20-4d63-b357-cfa1cde182a2">
<img width="1120" alt="스크린샷 2023-11-24 오전 4 52 01" src="https://github.com/DO-SOPT-APP6-NAVER-MAP/NAVER-MAP-iOS/assets/105407130/05dd135a-54f0-4b5a-9448-a3bb1dae9254">


### 📸 스크린샷


|뷰|설명|
|:------:|:---:|
|![Simulator Screenshot - iPhone 14 Pro - 2023-11-24 at 04 45 47](https://github.com/DO-SOPT-APP6-NAVER-MAP/NAVER-MAP-iOS/assets/105407130/768a4696-dea6-4775-85b0-8041a1bb4719)|   BottomSheet 뷰 UI  |
