### PR TITLE
[Feat] #33 - 길찾기 서버 통신

### DIFF
--- a/NAVER-MAP-iOS/Screen/FindingRoute/View/FindingRouteRootView.swift
+++ b/NAVER-MAP-iOS/Screen/FindingRoute/View/FindingRouteRootView.swift
@@ -67,6 +67,16 @@ extension FindingRouteRootView {
         findRouteCollectionView.delegate = forDelegate
         findRouteCollectionView.dataSource = forDatasource
     }
+    
+    func setupArriveText(forText: String) {
+        searchTopArriveTextField.do {
+            $0.text = forText
+        }
+    }
+    
+    func reloadCollectionView() {
+        findRouteCollectionView.reloadData()
+    }
 }
 
 private extension FindingRouteRootView {

--- a/NAVER-MAP-iOS/Screen/FindingRoute/ViewController/FindingRouteViewController.swift
+++ b/NAVER-MAP-iOS/Screen/FindingRoute/ViewController/FindingRouteViewController.swift
@@ -9,14 +9,30 @@ import UIKit
 
 final class FindingRouteViewController: UIViewController {
     
-    private let routeData: [FindingRouteModel] = FindingRouteModel.dummyData
+    private var placdId: Int
+    private var placeName: String 
+    private var routeData: [FindingRouteModel] = [FindingRouteModel]() {
+        didSet {
+            rootView.reloadCollectionView()
+        }
+    }
 
     // MARK: - UI Properties
 
     private let rootView = FindingRouteRootView()
 
     // MARK: - Life Cycle
-
+    
+    init(forPlacdId: Int, forPlaceName: String) {
+        self.placdId = 1
+        self.placeName = forPlaceName
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func loadView() {
         view = rootView
     }
@@ -26,12 +42,30 @@ final class FindingRouteViewController: UIViewController {
         
         hideNavigationBar()
         setupView()
+        fetchNetworkResult()
     }
 }
 
 private extension FindingRouteViewController {
     func setupView() {
         rootView.setupCollectionView(forDelegate: self, forDatasource: self)
+        rootView.setupArriveText(forText: placeName)
+    }
+    
+    func fetchNetworkResult() {
+        NetworkService.shared.placeService.getPlaceRoute(forPlaceId: placdId) { result in
+            switch result {
+            case .success(let response):
+                if let data = response?.data {
+                    var routeNetworkData = [FindingRouteModel]()
+                    data.directionLists.forEach {
+                        routeNetworkData.append(FindingRouteModel(imageURL: $0.route))
+                    }
+                    self.routeData = routeNetworkData
+                }
+            default: break
+            }
+        }
     }
 }
 

--- a/NAVER-MAP-iOS/Screen/FindingRoute/ViewController/FindingRouteViewController.swift
+++ b/NAVER-MAP-iOS/Screen/FindingRoute/ViewController/FindingRouteViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 
 final class FindingRouteViewController: UIViewController {
     
+    // MARK: - Properties
+
     private var placdId: Int
     private var placeName: String 
     private var routeData: [FindingRouteModel] = [FindingRouteModel]() {
@@ -42,9 +44,16 @@ final class FindingRouteViewController: UIViewController {
         
         hideNavigationBar()
         setupView()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
         fetchNetworkResult()
     }
 }
+
+// MARK: - private extension
 
 private extension FindingRouteViewController {
     func setupView() {
@@ -69,7 +78,11 @@ private extension FindingRouteViewController {
     }
 }
 
+// MARK: - UICollectionViewDelegate
+
 extension FindingRouteViewController: UICollectionViewDelegate { }
+
+// MARK: - UICollectionViewDataSource
 
 extension FindingRouteViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {


### PR DESCRIPTION
### 🌴 작업한 브랜치
- #33


### ✅ 작업한 내용
길찾기 부분 API 부착했습니다.



### ❗️PR Point
- FindingRouteViewController를 생성할 때 파라미터 값으로 forPlaceId(place의 id값)와 forPlaceName(place의 name값)을 전달해줘야 합니다!
   <img width="525" alt="image" src="https://github.com/DO-SOPT-APP6-NAVER-MAP/NAVER-MAP-iOS/assets/75093565/5ca6d682-6ad1-4263-a7fc-f7fdc5ffd5c5">

- 현재 서버에 placeId가 1인 경우에만 경로가 들어가 있어 초기화 시 우선 placeId를 1로 넣어뒀습니다. 
   ```
   init(forPlacdId:` Int, forPlaceName: String) {
        self.placdId = 1
        self.placeName = forPlaceName
        super.init(nibName: nil, bundle: nil)
    }
   ```


### 📸 스크린샷

https://github.com/DO-SOPT-APP6-NAVER-MAP/NAVER-MAP-iOS/assets/75093565/fdadede9-2a07-4e0a-9b4e-2c1805f9aa7d

<img width="106" alt="image" src="https://github.com/DO-SOPT-APP6-NAVER-MAP/NAVER-MAP-iOS/assets/75093565/e4d69ab6-2236-4ccf-9aa3-8a3b2804ecad">


</br></br>


- Resolved: #33
